### PR TITLE
Use get_block_headers_range RPC call to get ancestors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,5 @@ It takes the following optional flags:
 * `--wallet`: URL to the Monero Wallet RPC
 * `--daemon`: URL to the Monero Daemon RPC
 * `--nats`: URL to the NATS Streaming server
+* `--ignore-below-height`: Ignore Blocks and Transactions whose block height is below the configured value. Where ignoring means doing as little work as possible: Txs won't be published to nats; Blocks' ancestors won't be fetched, and then they won't be published to NATS
 * `--ancestors`: Max number of ancestor blocks' hashes to include with every published block

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 				Name:        "ignore-below-height",
 				Aliases:     []string{"i"},
 				Value:       0,
-				Usage:       "Ignores Blocks and Transactions which height lower than this value",
+				Usage:       "Ignores Blocks and Transactions with height lower than this value",
 				Destination: &ignoreBelowHeight,
 			},
 		},

--- a/rpc_block.go
+++ b/rpc_block.go
@@ -11,6 +11,10 @@ type RpcBlockHeader struct {
 	PrevHash  string `json:"prev_hash"`
 }
 
+type RpcBlockHeaders struct {
+	Headers []RpcBlockHeader `json:"headers"`
+}
+
 type RpcBlock struct {
 	BlockHeader RpcBlockHeader `json:"block_header"`
 	TxHashes    []string       `json:"tx_hashes"`
@@ -39,4 +43,30 @@ func (c *RPCClient) GetBlockByHash(ctx context.Context, hash string) (*RpcBlock,
 		return nil, err
 	}
 	return &rpcBlock, nil
+}
+
+type GetBlocksRangeParams struct {
+	StartHeight int `json:"start_height"`
+	EndHeight   int `json:"end_height"`
+}
+
+func NewGetBlocksRangePayload(start, end int) RPCRequestPayload {
+	return RPCRequestPayload{
+		ID:      "0",
+		JSONRPC: "2.0",
+		Method:  "get_block_headers_range",
+		Params: GetBlocksRangeParams{
+			StartHeight: start,
+			EndHeight:   end,
+		},
+	}
+}
+
+func (c *RPCClient) GetBlockHeadersRange(ctx context.Context, start, end int) ([]RpcBlockHeader, error) {
+	rpcReq := NewGetBlocksRangePayload(start, end)
+	rpcBlocks := RpcBlockHeaders{}
+	if err := c.MakeRequest(ctx, rpcReq, &rpcBlocks); err != nil {
+		return nil, err
+	}
+	return rpcBlocks.Headers, nil
 }


### PR DESCRIPTION
This reduces the number of RPC calls that we make per block